### PR TITLE
CI: install qemu before starting job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: c
 compiler: gcc
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install qemu -qqy
 script: make


### PR DESCRIPTION
💁 This change will fix [one of the build errors on Travis CI](https://travis-ci.org/friedrich12/DEOS/builds/327349346):
```
$ make
***
*** Error: Couldn't find a working QEMU executable.
*** Is the directory containing the qemu binary in your PATH
*** or have you tried setting the QEMU variable in conf/env.mk?
***
***
*** Error: Couldn't find a working QEMU executable.
*** Is the directory containing the qemu binary in your PATH
*** or have you tried setting the QEMU variable in conf/env.mk?
```